### PR TITLE
Making the Yay! headline configurable on the landing page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
         {{ partial "navigation" . }}
     </section>
     <main class="content" role="main" id="main-content">
-        <h1>Yay!</h1>
+        <h1>{{ .Site.Params.indexHeadline | default "Yay!" }}</h1>
         {{ $paginator := .Paginate (where .Data.Pages.ByDate.Reverse "Type" "post") 3 }}
         {{ range $paginator.Pages }}
         <article class="post post--preview">


### PR DESCRIPTION
This commits allows the default "Yay!" on the landing index page to be changed by a config change. 


Test it by setting 

```
[params]
indexheadline = "test headline"
```