### PR TITLE
Make stylesheet baseURL aware

### DIFF
--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="/css/style.css">
+<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/style.css">
 
 <link rel="apple-touch-icon" sizes="180x180" href="/img/apple-touch-icon.png">
 <link rel="icon" type="image/png" href="/img/favicon-32x32.png" sizes="32x32">


### PR DESCRIPTION
Hi Oliver! I love the simplicity (and style) of this theme!

I did, however, run into an issue loading the CSS when setting my `baseURL` to `http://example.com/blog/` that was resolved by the update in this PR.

I am VERY NEW to HUGO however and if there is a better way to accomplish this than I've found I'd love to know about it. Otherwise here is my solution in case others have the same issue.